### PR TITLE
add Nmap::XML.load(text)

### DIFF
--- a/lib/nmap/xml.rb
+++ b/lib/nmap/xml.rb
@@ -20,8 +20,8 @@ module Nmap
     #
     # Creates a new XML object.
     #
-    # @param [String] path
-    #   The path to the Nmap XML scan file.
+    # @param [String] document
+    #   The path to the Nmap XML scan file or Nokogiri::XML::Document.
     #
     # @yield [xml]
     #   If a block is given, it will be passed the new XML object.
@@ -29,11 +29,30 @@ module Nmap
     # @yieldparam [XML] xml
     #   The newly created XML object.
     #
-    def initialize(path)
-      @path = File.expand_path(path)
-      @doc = Nokogiri::XML(open(@path))
-
+    def initialize(document)
+      if Nokogiri::XML::Document === document
+        @doc = document
+      else
+        @path = File.expand_path(document)
+        @doc = Nokogiri::XML(open(@path))
+      end
       yield self if block_given?
+    end
+
+    #
+    # Creates a new XML object from XML text.
+    #
+    # @param [String] text
+    #   XML text of the scan file
+    #
+    # @yield [xml]
+    #   If a block is given, it will be passed the new XML object.
+    #
+    # @yieldparam [XML] xml
+    #   The newly created XML object.
+    #
+    def self.load(text, &block)
+      Nmap::XML.new(Nokogiri::XML(text), &block)
     end
 
     #
@@ -123,8 +142,8 @@ module Nmap
     def run_stats
       each_run_stat.to_a
     end
-    
-    # 
+
+    #
     # Parses the essential runstats information
     #
     # @return [RunStats]

--- a/spec/xml_spec.rb
+++ b/spec/xml_spec.rb
@@ -10,6 +10,10 @@ describe XML do
     subject.version.should == '1.04'
   end
 
+  it "should create object via #load" do
+    subject.version.should == described_class.load(File.read(path)).version
+  end
+
   it "should parse the scanner version" do
     subject.scanner.version == '4.68'
   end


### PR DESCRIPTION
Hey,
This change extends Nmap::XML initializer. Now it's possible to create Nmap::XML object from text.
It's useful when results are stored in database and not in files.
