### PR TITLE
fix infinite loop

### DIFF
--- a/lib/nmap/xml/script.rb
+++ b/lib/nmap/xml/script.rb
@@ -57,7 +57,7 @@ module Nmap
       #   The parsed data.
       #
       def parse_tables(node)
-        if (tables = @node.xpath('table')).empty?
+        if (tables = node.xpath('table')).empty?
           return
         end
 


### PR DESCRIPTION
the function "parse_tables" gets the parameter "node", but accesses "@node". This ends in an infinite loop, if the function is called recursively, depending on the structure of the XML.